### PR TITLE
Update amount input to number type

### DIFF
--- a/app/templates/transaction.html
+++ b/app/templates/transaction.html
@@ -33,7 +33,7 @@
             <div class="field-body">
               <div class="field is-narrow">
                 <p class="control has-icons-left">
-                  {{ form.amount(size=20, class="input", placeholder="0.00") }}
+                  {{ form.amount(size=20, class="input", type="number", placeholder="0.00") }}
                   <span class="icon is-small is-left">
                     <i class="fas fa-solid fa-coins"></i>
                   </span>


### PR DESCRIPTION
From mobile browsers, it would be preferable to display the number keypad instead character keyboard when the "Amount" field is selected. I've updated the Amount field to a number type to achieve this result.
![image](https://user-images.githubusercontent.com/1017310/141381259-f8302783-b20e-4103-b61d-017edb962e92.png)
