### PR TITLE
Package bread bucket as a mobile application

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -260,3 +260,6 @@ dist
 
 **/*.buckets
 *.css
+!/build
+/build/*
+!/build/.gitkeep

--- a/MobileDockerfile
+++ b/MobileDockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+FROM ubuntu:20.04
+
+ENV TZ=America/New_York
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN dpkg --add-architecture i386
+RUN apt update
+RUN apt-get install -y wget build-essential ccache git zlib1g-dev python3 python3-dev python3-pip libncurses5:i386 libstdc++6:i386 zlib1g:i386 unzip ant ccache autoconf libtool libssl-dev libffi-dev zip
+
+# Download Android SDK
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip
+RUN unzip commandlinetools-linux-7583922_latest.zip
+RUN mkdir /android-sdk
+RUN yes | /cmdline-tools/bin/sdkmanager --sdk_root=/android-sdk --licenses
+RUN /cmdline-tools/bin/sdkmanager --sdk_root=/android-sdk "platforms;android-27"
+ENV ANDROIDSDK=/android-sdk
+
+RUN /cmdline-tools/bin/sdkmanager --sdk_root=/android-sdk  "build-tools;28.0.2"
+
+# Download Android NDK
+RUN wget https://dl.google.com/android/repository/android-ndk-r19c-linux-x86_64.zip
+RUN unzip android-ndk-r19c-linux-x86_64.zip
+ENV ANDROIDNDK=/android-ndk-r19c
+ENV ANDROIDAPI="27"
+ENV NDKAPI="21"
+
+RUN mkdir /app
+COPY main.py /app
+COPY /app /app/app
+
+RUN pip install python-for-android cython virtualenv
+
+# Purge open jdk and reinstall becuase one of the deps above pulls stuff it should not
+RUN apt-get remove -y openjdk*
+RUN apt-get install -y openjdk-8-jdk-headless
+
+COPY build-mobile.sh /build-mobile.sh
+RUN chmod +x build-mobile.sh
+
+RUN mkdir /build
+
+CMD sh /build-mobile.sh

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,8 @@
 import os
-
 from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from sqlalchemy.pool import NullPool
-from flask_login import LoginManager
+from . import constants
 
 db = SQLAlchemy(engine_options={
     'echo': False,
@@ -11,27 +10,34 @@ db = SQLAlchemy(engine_options={
     'poolclass': NullPool
 })
 
-login_manager = LoginManager()
-
-
 app = Flask(__name__)
 
 app.config.from_mapping(
     SECRET_KEY='dev'
 )
 
-app.config['HTTP_BASIC_AUTH_USERNAME'] = os.environ.get("HTTP_BASIC_AUTH_USERNAME", default='buckets')
-app.config['HTTP_BASIC_AUTH_PASSWORD'] = os.environ.get("HTTP_BASIC_AUTH_PASSWORD", default='dev')
+if constants.RUNNING_ON_ANDROID:
+    from android.permissions import request_permissions, Permission
+    from android.storage import primary_external_storage_path
 
-db_file = os.environ.get("DB_FILE", default='/app/db.buckets')
+    request_permissions([Permission.WRITE_EXTERNAL_STORAGE])
+
+    BASE_DIR = os.path.join(primary_external_storage_path() , 'Documents')
+    db_file = os.path.join(BASE_DIR, "db.buckets")
+else:
+    from flask_login import LoginManager
+    app.config['HTTP_BASIC_AUTH_USERNAME'] = os.environ.get("HTTP_BASIC_AUTH_USERNAME", default='buckets')
+    app.config['HTTP_BASIC_AUTH_PASSWORD'] = os.environ.get("HTTP_BASIC_AUTH_PASSWORD", default='dev')
+    login_manager = LoginManager()
+    login_manager.init_app(app)
+    login_manager.login_view = '/login'
+    db_file = os.environ.get("DB_FILE", default='/app/db.buckets')
+
 app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + db_file
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
 app.logger.warn("Connecting to SQLite Database File: %s", db_file)
 db.init_app(app)
-login_manager.init_app(app)
 
 from . import views
 app.register_blueprint(views.views)
-login_manager.login_view = '/login'
-

--- a/app/constants.py
+++ b/app/constants.py
@@ -1,0 +1,3 @@
+from os import environ
+
+RUNNING_ON_ANDROID = "ANDROID_ARGUMENT" in environ

--- a/app/mocks.py
+++ b/app/mocks.py
@@ -1,0 +1,13 @@
+class LimiterMock(object):
+    def limit(self, _):
+        def inner(func):
+            return func
+        return inner
+
+class LoginManagerMock(object):
+    def user_loader(self, func):
+        return func
+    def login_required(self, func):
+        return func
+    def login_user(self, func):
+        return func

--- a/app/models.py
+++ b/app/models.py
@@ -23,7 +23,7 @@ class Account(db.Model):
                 .query
                 .outerjoin(Transaction)
                 .group_by(Account.id)
-                .where(Account.closed==0)
+                .filter(Account.closed==0)
                 .order_by(func.count(Transaction.id).desc(), Account.name))
 
     def __repr__(self):
@@ -41,15 +41,13 @@ class Transaction(db.Model):
 
     @staticmethod
     def top(limit, account=None):
-        tx = (Transaction
+        return (Transaction
                 .query
-                .where(
+                .filter(
                     or_(((account is not None) and (Transaction.account_id==account))
                         ,(account is None)))
                 .order_by(Transaction.posted.desc())
                 .limit(limit))
-        print(tx)
-        return tx
 
     def __repr__(self):
         return '<Transaction %r>' % self.id

--- a/build-mobile.sh
+++ b/build-mobile.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+p4a apk --private /app \
+    --package=com.bread.bucket \
+    --name "Bread Bucket Mobile" \
+    --version 0.1 \
+    --bootstrap=webview \
+    --requirements=flask,Flask-WTF,WTForms,Flask-SQLAlchemy,SQLAlchemy \
+    --port=5000 \
+    --dist_name BreadBucketMobile \
+    --permission WRITE_EXTERNAL_STORAGE
+mv /BreadBucketMobile*.apk /build/BreadBucketMobile.apk

--- a/main.py
+++ b/main.py
@@ -1,0 +1,4 @@
+from app import app
+
+if __name__ == "__main__":
+    app.run()

--- a/package.json
+++ b/package.json
@@ -10,7 +10,14 @@
     "start": "npm run css-watch",
     "docker-build": "docker build . -t cmeury/bread-bucket:latest",
     "docker-push": "docker push cmeury/bread-bucket:latest",
-    "publish": "npm run css-build && npm run docker-build && npm run docker-push"
+    "publish": "npm run css-build && npm run docker-build && npm run docker-push",
+    "docker-build-mobile": "docker build -f MobileDockerfile . -t bread-bucket-apk",
+    "docker-build-mobile-apk": "docker run -v ~/Source/bread-bucket/build:/build:rw bread-bucket-apk",
+    "docker-full-mobile-build": "npm run docker-build-mobile && npm run docker-build-mobile-apk",
+    "docker-connect": "docker run -it -v ~/Source/bread-bucket/build:/build:rw --entrypoint bash bread-bucket-apk",
+    "install-apk": "adb install ./build/*.apk",
+    "emulator": "~/Android/Sdk/emulator/emulator -avd Pixel_3a_API_30 -netdelay none -netspeed full",
+    "emulator-logs": "adb logcat | grep python"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
I've been using this site personally and I keep thinking, for my purposes, it would be better to have a mobile app. Instead of going out to the internet, the app could interface with a local `.buckets` file perhaps tracked by a file syncing application (nextcloud for my purposes) and that would handle the syncing.

I've spent a bit of time doing just that. In this PR, you'll find the addition of a MobileDockerfile that scripts out the process of setting up the build env and "packaging" the flask app as an Android application. For the Android app, you don't really need some of the functionality built into the current web-app, such as authentication, and limiting, so I've introduced environment sniffing and some branching code depending on the context in which the application is running.

This PR is a rough-in of the Android packaging. Currently there are some caveats including:
* The app assumes a `db.buckets` file to exist at `/storage/emulated/0/Documents` on the device. Ideally the user would be prompted for a file location at first run, and this would be stored for subsequent runs
* There is no fancy app icon, the default for `python-for-android` is used
* Many of the commands I've included in the `package.json` assume things such as the Android SDK installed in a specific location, an AVD is created with a specific name, and `adb` is present in the path

I wanted to create this as a Draft PR so that we can have a discussion on where this should exist. Should it be merged in? If so, I've structured the code in such as way, that the "Android" bits are easily distinguishable. Should this exist as a separate project? Let's discuss.

I've included some images of the app running for your viewing pleasure below:
![about](https://user-images.githubusercontent.com/1017310/142502158-53e3583c-69f2-4f51-be78-cd8c140bdbdf.png)
![Transaction](https://user-images.githubusercontent.com/1017310/142502162-fc6ad125-f4cd-49f4-9552-c4f8025dc13c.png)

